### PR TITLE
FIXES #5: accepts quoted value for header field 'algorithm'

### DIFF
--- a/lib/net/http/digest_auth.rb
+++ b/lib/net/http/digest_auth.rb
@@ -86,7 +86,7 @@ class Net::HTTP::DigestAuth
     params = {}
     challenge.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
 
-    challenge =~ /algorithm=(.*?)([, ]|$)/
+    challenge =~ /algorithm="?(.*?)"?([, ]|$)/
 
     params['algorithm'] = $1 || 'MD5'
 

--- a/test/test_net_http_digest_auth.rb
+++ b/test/test_net_http_digest_auth.rb
@@ -106,6 +106,12 @@ class TestNetHttpDigestAuth < MiniTest::Unit::TestCase
     assert_equal 'unknown algorithm "bogus"', e.message
   end
 
+  def test_auth_header_quoted_algorithm
+    @header << 'algorithm="MD5"'
+
+    assert_equal expected, @da.auth_header(@uri, @header, 'GET')
+  end
+
   def test_make_cnonce
     da = Net::HTTP::DigestAuth.new
 


### PR DESCRIPTION
I stumbled upon an issue with the algorithm header field. It seems to me that ruby is quoting the header values and therefor produces an invalid value resulting in the Exception described in https://github.com/drbrain/net-http-digest_auth/issues/5.
Just to be sure I checked the server response and everything seems to be fine here (i.e algorithm=MD5).
This commit enables the gem to accept both, quoted and unquoted values.
