### PR TITLE
Update digest_auth.rb

### DIFF
--- a/lib/net/http/digest_auth.rb
+++ b/lib/net/http/digest_auth.rb
@@ -56,7 +56,7 @@ class Net::HTTP::DigestAuth
 
   def initialize ignored = :ignored
     mon_initialize
-    @nonce_count = -1
+    @nonce_count = 0
   end
 
   ##


### PR DESCRIPTION
The nonce_count for the first authorization request should be 1. Currently 0 is used, which fails causes the authentication to fail with some servers (e.g. Node.js). This changes the initial nonce_count value to 0 so that the value used for the first request will be 1.
