### PR TITLE
latest rfc does not specify a limit on response header and this is in…

### DIFF
--- a/lib/net/http/digest_auth.rb
+++ b/lib/net/http/digest_auth.rb
@@ -142,7 +142,7 @@ class Net::HTTP::DigestAuth
           "cnonce=\"#{cnonce}\"",
         ]
       end,
-      "response=\"#{algorithm.hexdigest(request_digest)[0, 32]}\"",
+      "response=\"#{algorithm.hexdigest(request_digest)}\"",
       if params.key? 'opaque' then
         "opaque=\"#{params['opaque']}\""
       end

--- a/test/test_net_http_digest_auth.rb
+++ b/test/test_net_http_digest_auth.rb
@@ -89,7 +89,7 @@ class TestNetHttpDigestAuth < Minitest::Test
 
   def test_auth_header_sha1
     @expected[2] = 'algorithm=SHA1'
-    @expected[8] = 'response="2cb62fc18f7b0ebdc34543f896bb7768"'
+    @expected[8] = 'response="2cb62fc18f7b0ebdc34543f896bb77686b4115e4"'
 
     @header << 'algorithm=SHA1'
 


### PR DESCRIPTION
…stead

determined by the digest algorithm used instead
https://tools.ietf.org/html/rfc7616#section-3.4.2